### PR TITLE
Remove blocking test code.

### DIFF
--- a/src/test/java/io/jonashackt/springbootgraal/HelloRouterTest.java
+++ b/src/test/java/io/jonashackt/springbootgraal/HelloRouterTest.java
@@ -1,43 +1,19 @@
 package io.jonashackt.springbootgraal;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.web.reactive.function.client.ClientResponse;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import org.springframework.test.web.reactive.server.WebTestClient;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class HelloRouterTest {
 
-	@LocalServerPort
-	private int port;
-
-	private WebClient webClient;
-
-	@BeforeEach
-	public void init() {
-		webClient = WebClient.create("http://localhost:" + port);
-	}
-
 	@Test void
-	should_call_reactive_rest_resource() {
-		Mono<ClientResponse> result = webClient
-				.get()
-				.uri("/hello")
-				.accept(MediaType.TEXT_PLAIN)
-				.exchange();
-
-		assertEquals(HelloHandler.RESPONSE_TEXT, result.flatMap(response -> response.bodyToMono(String.class)).block());
+	should_call_reactive_rest_resource(@Autowired WebTestClient webTestClient) {
+		webTestClient.get().uri("/hello")
+			.accept(MediaType.TEXT_PLAIN)
+			.exchange()
+			.expectBody(String.class).isEqualTo(HelloHandler.RESPONSE_TEXT);
 	}
-
 }


### PR DESCRIPTION
Your post and project is great! It does not deserve `.block()` in a test.

I used the `WebTestClient` in my PR, which does this internally… 

Another way to do this is with Project Reactors test facilities (The `StepVerifier`):

```
Mono<ClientResponse> result = webClient
			.get()
			.uri("/hello")
			.accept(MediaType.TEXT_PLAIN)
			.exchange();

result.flatMap(r -> r.bodyToMono(String.class))
		.as(StepVerifier::create)
		.expectNext(HelloHandler.RESPONSE_TEXT)
		.verifyComplete();
```